### PR TITLE
Add correlations field to rule object.

### DIFF
--- a/detection_rules/schemas/definitions.py
+++ b/detection_rules/schemas/definitions.py
@@ -53,11 +53,13 @@ TIMELINE_TEMPLATES: Final[dict] = {
 
 
 NonEmptyStr = NewType('NonEmptyStr', str, validate=validate.Length(min=1))
+ValidUUIDStr = NewType('ValidUUIDStr', str, validate=validate.Regexp(UUID_PATTERN))
 
 BranchVer = NewType('BranchVer', str, validate=validate.Regexp(BRANCH_PATTERN))
 CardinalityFields = NewType('CardinalityFields', List[NonEmptyStr], validate=validate.Length(min=0, max=3))
 CodeString = NewType("CodeString", str)
 ConditionSemVer = NewType('ConditionSemVer', str, validate=validate.Regexp(CONDITION_VERSION_PATTERN))
+Correlations = NewType('Correlations', List[ValidUUIDStr])
 Date = NewType('Date', str, validate=validate.Regexp(DATE_PATTERN))
 FilterLanguages = Literal["kuery", "lucene"]
 Interval = NewType('Interval', str, validate=validate.Regexp(INTERVAL_PATTERN))
@@ -80,9 +82,8 @@ TechniqueURL = NewType('TechniqueURL', str, validate=validate.Regexp(TECHNIQUE_U
 ThresholdValue = NewType("ThresholdValue", int, validate=validate.Range(min=1))
 TimelineTemplateId = NewType('TimelineTemplateId', str, validate=validate.OneOf(list(TIMELINE_TEMPLATES)))
 TimelineTemplateTitle = NewType('TimelineTemplateTitle', str, validate=validate.OneOf(TIMELINE_TEMPLATES.values()))
-UUIDString = NewType('UUIDString', str, validate=validate.Regexp(UUID_PATTERN))
+UUIDString = NewType('UUIDString', ValidUUIDStr)
 
-Correlations = NewType('Correlations', List[UUIDString])
 
 
 

--- a/detection_rules/schemas/definitions.py
+++ b/detection_rules/schemas/definitions.py
@@ -82,6 +82,10 @@ TimelineTemplateId = NewType('TimelineTemplateId', str, validate=validate.OneOf(
 TimelineTemplateTitle = NewType('TimelineTemplateTitle', str, validate=validate.OneOf(TIMELINE_TEMPLATES.values()))
 UUIDString = NewType('UUIDString', str, validate=validate.Regexp(UUID_PATTERN))
 
+Correlations = NewType('Correlations', List[UUIDString])
+
+
+
 
 # experimental machine learning features and releases
 MachineLearningType = Literal['DGA', 'ProblemChild']


### PR DESCRIPTION
This implements the following task:

- Add schema and validation support in [detection-rules](https://github.com/elastic/detection-rules) for a new field within the Rule [object](https://github.com/elastic/detection-rules/blob/3ba777c1b15a06f3a314540a84f654b0152f5e9e/detection_rules/rule.py#L383-L548) with the following requirements
  - **Name**: correlations
  - **Value type**: an optional array of UUIDs
  - Applies to all rule [types](https://github.com/elastic/detection-rules/blob/3ba777c1b15a06f3a314540a84f654b0152f5e9e/detection_rules/rule.py#L553)
  - Is only valid if a threat object is set within a rule (for validation)

***

## To test this

- Look at the testcases that are added in this PR, and run `$ python -m detection_rules test`

## Notes

- Currently, this looks like the second kind of semantic validation that caters for fields depending on the presence or absence of other fields. If there will ever be a third, just adding more of them to `DataValidator` and calling them one by is probably not the way to go.
- The task doesn't specify how these correlating rules will be used: If there is rule A and rule B which correlate, to they list each other in `correlations`? Or will there be higher-level rules that only check for a list of `correlations` which then match a threat?
- Should there be cross-rule validation to verify that the referenced rules actually exist in the repository?
