### PR TITLE
Add brute force ssh rta

### DIFF
--- a/rta/brute_force_ssh.py
+++ b/rta/brute_force_ssh.py
@@ -1,0 +1,53 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+# Name: Potential SSH Brute Force Detected on Privileged Account
+# RTA: brute_force_ssh.py
+# ATT&CK: T1110
+# Description: Simulates brute force or password spraying tactics.
+#              Remote audit failures must be enabled to trigger: `auditpol /set /subcategory:"Logon" /failure:enable`
+
+import random
+import string
+import sys
+import time
+
+from . import common
+from . import RtaMetadata
+
+
+metadata = RtaMetadata(
+    uuid="a5f0d057-d540-44f5-924d-c6a2ae92f045", # this was created in a python shell with uuid.uuid4() -- proper way?
+    platforms=["linux"],
+    endpoint=[],
+    siem=[
+        {"rule_id": "a5f0d057-d540-44f5-924d-c6a2ae92f045", "rule_name": "Potential SSH Brute Force Detected on Privileged Account"}
+    ],
+    techniques=["T1110"],
+)
+
+
+@common.requires_os(metadata.platforms)
+def main(remote_host=None):
+    if not remote_host:
+        common.log("A remote host is required to detonate this RTA", "!")
+        return common.MISSING_REMOTE_HOST
+
+    common.enable_logon_auditing(remote_host)
+
+    common.log("Brute forcing login with invalid password against root@{}".format(remote_host))
+
+    command = ["sshpass", "-p", "NotThePassword", "root@{}".format(remote_host)] # root hardcoded. could be expanded to also test non-privileged accounts
+
+    # fail 4 times - the first 3 concurrently and wait for the final to complete
+    for i in range(4):
+        common.execute(command, wait=i == 3)
+
+    # allow time for audit event to process
+    time.sleep(2)
+
+
+if __name__ == "__main__":
+    exit(main(*sys.argv[1:]))

--- a/rta/brute_force_ssh.py
+++ b/rta/brute_force_ssh.py
@@ -35,15 +35,16 @@ def main(remote_host=None):
         common.log("A remote host is required to detonate this RTA", "!")
         return common.MISSING_REMOTE_HOST
 
-    common.enable_logon_auditing(remote_host)
+    # nope, not available on linux
+    # common.enable_logon_auditing(remote_host)
 
     common.log("Brute forcing login with invalid password against root@{}".format(remote_host))
 
-    command = ["sshpass", "-p", "NotThePassword", "root@{}".format(remote_host)] # root hardcoded. could be expanded to also test non-privileged accounts
+    command = ["sshpass", "-p", "NotThePassword", "ssh", "root@{}".format(remote_host)] # root hardcoded. could be expanded to also test non-privileged accounts
 
-    # fail 4 times - the first 3 concurrently and wait for the final to complete
-    for i in range(4):
-        common.execute(command, wait=i == 3)
+    # try 10 times - the first 9 concurrently and wait for the final to complete
+    for i in range(10):
+        common.execute(command, wait=(i==9))
 
     # allow time for audit event to process
     time.sleep(2)

--- a/rta/brute_force_ssh.py
+++ b/rta/brute_force_ssh.py
@@ -19,7 +19,7 @@ from . import RtaMetadata
 
 
 metadata = RtaMetadata(
-    uuid="a5f0d057-d540-44f5-924d-c6a2ae92f045", # this was created in a python shell with uuid.uuid4() -- proper way?
+    uuid="bc88e8ab-0aff-4d74-a0e1-73ed489893ce", # this was created in a python shell with uuid.uuid4() -- proper way?
     platforms=["linux"],
     endpoint=[],
     siem=[


### PR DESCRIPTION
This implements the following task:

- Build a stack from a trial [cloud](https://cloud.elastic.co/) deployment and pick any detection [rule](https://github.com/elastic/detection-rules/tree/main/rules) which does not have an existing [RTA](https://github.com/elastic/detection-rules/tree/main/rta) and create an RTA for it
  - Build any stack version from cloud
  - Setup an endpoint agent on a host (VM, etc.)
  - Execute the RTA and collect generated events
  - Show proof of a triggered rule

***

> Build a stack from a trial [cloud](https://cloud.elastic.co/) deployment

https://skh-8-4-2-test.kb.us-central1.gcp.cloud.es.io:9243/ , happy to share credentials.

>  and pick any detection [rule](https://github.com/elastic/detection-rules/tree/main/rules) which does not have an existing [RTA](https://github.com/elastic/detection-rules/tree/main/rta) and create an RTA for it.

I picked [Potential SSH Brute Force Detected on Privileged Account](https://github.com/elastic/detection-rules/blob/main/rules/linux/credential_access_potential_linux_ssh_bruteforce_root.toml)

### To test this:

- Have the elastic stack running somewhere, including Integrations. I tested with 8.4.2.
- Have a target linux VM with `ssh` login enabled, passwort logins and root login allowed. On Ubuntu that means
  - install `ssh`
  - then `PasswordAuthentication yes` and `PermitRootLogin yes` in `/etc/ssh/sshd_config`
  - restart the service with `sytemctl restart ssh.service`
  - set a password for `root` (first `sudo su`, then `passwd`)

- Enroll the target system in Elastic Endpoint, (Kibana -> Security -> Manage -> Endpoints)

- Have another linux VM with this branch checked out and `sshpass` installed (or use linux as your main workstation).
- Install `python` requirements as described in the main `README.md`
- Run `$ python -m rta --name=brute_force_ssh "IP_OF_TARGET_VM"`

- Log in to Kibana, find your way to the Hosts view in the Security solution (Kibana -> Security -> Explore -> Hosts)
- View the details of your host and find that it had indeed a few authentication failures for `root`:

![image](https://user-images.githubusercontent.com/189073/193649643-adb37999-0a21-4114-92ce-c168cfb3cc85.png)

- Find no triggered rule, anywhere, and investigate why that is so. Go to Kibana -> Security -> Manage -> Rules, and find that the rule `Potential SSH Brute Force Detected on Privileged Account` is not listed, but there is `Endpoint Security`, which is enabled. Ponder if some rules end up within `Endpoint Security`, while others are explicitly listed? Stop for now.

***

**Notes**
- This RTA could just as well be written to be executed on Windows, even if the rule it tests is specific to Linux.
- It's also very specific in that it needs a target linux system with an insecure configuration, and the `sshpass` utility installed on the system that runs the RTA. If this is to be run in an automated way somewhere, there needs to be more automation around it.
- There's now `brute_force_ssh.py` (mine) and `ssh_bruteforce.py` testing another rule, which is unfortunate but which I noticed a bit late. I also noted that the naming and organization of the RTA scripts is less strictly organized that that of the `rules` directory which might be a possible improvement.





